### PR TITLE
Added ability to define preprocessor for a cmd selection

### DIFF
--- a/templates/cmd/buildSelectorModal.html
+++ b/templates/cmd/buildSelectorModal.html
@@ -1,0 +1,20 @@
+<div class="template modal" style="width: 320px;">
+    <div class="modal-header">
+        <h1 class="dialog-title">Select a Build</h1>
+    </div>
+    <div class="modal-body">
+        <form>
+            <div class="input-group">
+                <select name="build_name" id="build_name" style="width:290px;" class="form-control">
+                    {{#builds}}
+                    <option value="{{.}}">{{.}}</option>
+                    {{/builds}}
+                </select>
+            </div>
+        </form>
+    </div>
+    <div class="modal-footer">
+        <button class="dialog-button btn " data-button-id="cancel">Cancel</button>
+        <button class="dialog-button btn select-button primary" id="select-button" data-button-id="select-button">Use</button>
+    </div>
+</div>


### PR DESCRIPTION
In this particular case, added ability to select target build profile from app.json for app watch. So if app.json has 4 builds like so:

    "builds": {
        "classic-neptune": {
            "toolkit": "classic",
            "theme": "theme-neptune"
         },
        "classic-crisp": {
            "toolkit": "classic",
            "theme": "theme-crisp"
        },
        "modern-neptune": {
            "toolkit": "modern",
            "theme": "theme-neptune"
        },
        "modern-cupertino": {
            "toolkit": "modern",
            "theme": "theme-cupertino"
        }
    }
It will try to read the app.json and show you a select box to choose one of the builds to use with app watch. 
![image](https://cloud.githubusercontent.com/assets/9660362/7340758/fde1f652-ec59-11e4-8509-c395b24182b3.png)

If there is only one build, it will just skip this step and run the default cmd.